### PR TITLE
Fix doMC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,13 +47,14 @@ Imports:
 Suggests: 
     BiocStyle,
     combinat,
-    doMC,
     foreach,
     knitr,
     pcaMethods,
     rmarkdown,
     testthat,
     VGAM
+Enhances:
+    doMC
 VignetteBuilder: 
     knitr
 biocViews: SingleCell, RNASeq, Visualization, Transcriptomics,


### PR DESCRIPTION
This PR changes how doMC is used in the package. Specifically, on Windows where doMC is not available, we now always fall back to sampling chains serially. 